### PR TITLE
fixed typo in $help command

### DIFF
--- a/commands/misc/help.go
+++ b/commands/misc/help.go
@@ -60,7 +60,7 @@ var Help = pkg.Command{
 		}
 
 		if !ctx.IsDM() {
-			_, err := ctx.Reply("Ett direkt meddelande har skickats till dig med alla kommandon. Du finner dem längst upp till vänster.")
+			_, err := ctx.Reply("Ett direktmeddelande har skickats till dig med alla kommandon. Du finner dem längst upp till vänster.")
 
 			if err != nil {
 				return err


### PR DESCRIPTION
Before, the message when running the command ```$help``` said "ett direkt meddelande [...]". I fixed the typo and changed it to "ett direktmeddelande [...]".