### PR TITLE
"youtu.be" host name compatability for music channel 

### DIFF
--- a/pkg/music.go
+++ b/pkg/music.go
@@ -130,7 +130,7 @@ func (controller *Controller) AddToQueue(context *Context) error {
 	songURL := context.Args[0]
 
 	u, err := url.ParseRequestURI(songURL)
-	if err != nil || u.Hostname() != "www.youtube.com" || u.Hostname() != "youtu.be" {
+	if err != nil || u.Hostname() != "www.youtube.com" || u.Hostname() != "youtu.be" || u.Hostname() != "m.youtube.com" {
 		context.Reply("Du måste skicka en youtube-länk.")
 		return nil
 	}

--- a/pkg/music.go
+++ b/pkg/music.go
@@ -130,8 +130,8 @@ func (controller *Controller) AddToQueue(context *Context) error {
 	songURL := context.Args[0]
 
 	u, err := url.ParseRequestURI(songURL)
-	if err != nil || u.Hostname() != "www.youtube.com" {
-		context.Reply("Du måste skicka en youtube länk.")
+	if err != nil || u.Hostname() != "www.youtube.com" || u.Hostname() != "youtu.be" {
+		context.Reply("Du måste skicka en youtube-länk.")
 		return nil
 	}
 


### PR DESCRIPTION
- Added another type of youtube link according to solution 1 given in issue #4 
- Fixed typo ("youtube länk" &rarr; "youtube-länk") right below.
- Warning: Code has not been tested if it still works as I don't have a Go compiler.
Fix #4 