### PR TITLE
Anna will not try to help you if you typed in new command while mention

### DIFF
--- a/events/messageEvent.go
+++ b/events/messageEvent.go
@@ -73,14 +73,16 @@ func MessageHandler(server *internal.Server) func(*discordgo.Session, *discordgo
 		command, found := server.CommandHandler.GetCommand(commandName)
 
 		if !found {
-			replyMessage := "Kunde inte hitta kommandot. Testa `$help` för att se alla kommandon."
+			if !mentionsMe {
 
-			if channel.Type == discordgo.ChannelTypeGuildText {
-				replyMessage = message.Author.Mention() + ", " + strings.ToLower(string(replyMessage[0])) + replyMessage[1:]
+				replyMessage := "Kunde inte hitta kommandot. Testa `$help` för att se alla kommandon."
+
+				if channel.Type == discordgo.ChannelTypeGuildText {
+					replyMessage = message.Author.Mention() + ", " + strings.ToLower(string(replyMessage[0])) + replyMessage[1:]
+				}
+
+				discord.ChannelMessageSend(message.ChannelID, replyMessage)
 			}
-
-			discord.ChannelMessageSend(message.ChannelID, replyMessage)
-
 			return
 		}
 


### PR DESCRIPTION
Added an if-statement to check if bot is mention while a command is not found which will allow users to mention the bots name without triggering a popup.

This will break the feature that reminds the user if they have typed unrecognized command while using the @-way to write commands.